### PR TITLE
Use target proof-of-stake spacing not proof-of-work spacing to calculate expected time to stake

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -61,6 +61,7 @@ extern std::map<uint256, CBlockIndex*> mapBlockIndex;
 extern std::set<std::pair<COutPoint, unsigned int> > setStakeSeen;
 extern CBlockIndex* pindexGenesisBlock;
 extern unsigned int nTargetSpacing;
+extern unsigned int nTargetStakeSpacing;
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
 extern unsigned int nNodeLifespan;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -942,7 +942,7 @@ void BitcoinGUI::updateStakingIcon()
     if (nLastCoinStakeSearchInterval && nWeight)
     {
         uint64_t nNetworkWeight = GetPoSKernelPS();
-        unsigned nEstimateTime = nTargetSpacing * nNetworkWeight / nWeight;
+        unsigned nEstimateTime = nTargetStakeSpacing * nNetworkWeight / nWeight;
 
         QString text;
         if (nEstimateTime < 60)


### PR DESCRIPTION
The tooltip for the "expected time to earn reward" was off by a factor of 12.
