### PR TITLE
Use coins and difficulty to estimate time to earn

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -941,8 +941,9 @@ void BitcoinGUI::updateStakingIcon()
 
     if (nLastCoinStakeSearchInterval && nWeight)
     {
+        unsigned long nEstimateTime;
+        pwalletMain->GetExpectedStakeTime(nEstimateTime);
         uint64_t nNetworkWeight = GetPoSKernelPS();
-        unsigned nEstimateTime = nTargetStakeSpacing * nNetworkWeight / nWeight;
 
         QString text;
         if (nEstimateTime < 60)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1553,6 +1553,40 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, ui
     return true;
 }
 
+bool CWallet::GetExpectedStakeTime(uint64_t& nExpected)
+{
+    unsigned int nBits = GetNextTargetRequired(pindexBest, true);
+    CBigNum bnTarget;
+    bnTarget.SetCompact(nBits);
+    int64_t nBalance = GetBalance();
+    set<pair<const CWalletTx*,unsigned int> > setCoins;
+    int64_t nValueIn = 0;
+    double fail = 1;
+
+    if (!SelectCoinsSimple(nBalance, GetTime(), nCoinbaseMaturity + 10, setCoins, nValueIn))
+        return false;
+
+    CTxDB txdb("r");
+    BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
+    {
+        CTxIndex txindex;
+        {
+            LOCK2(cs_main, cs_wallet);
+            if (!txdb.ReadTxIndex(pcoin.first->GetHash(), txindex))
+                continue;
+        }
+
+        // p(A or B) = p(not((not A) and (not B))) = 1 - (p(1 - A) * p(1 - B))
+        int64_t nTimeWeight = GetWeight((int64_t)pcoin.first->nTime, (int64_t)GetTime());
+        CBigNum bnCoinDayWeight = CBigNum(pcoin.first->vout[pcoin.second].nValue) * nTimeWeight / COIN / (24 * 60 * 60);
+        CBigNum bnTries(CBigNum(~uint256(0)) / (bnCoinDayWeight * bnTarget));
+        fail *= 1 - 1.0/bnTries.getulong();
+    }
+
+    nExpected = 1 / (1 - fail);
+    return true;
+}
+
 bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64_t nSearchInterval, int64_t nFees, CTransaction& txNew, CKey& key)
 {
     CBlockIndex* pindexPrev = pindexBest;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -189,6 +189,7 @@ public:
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     bool GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, uint64_t& nMaxWeight, uint64_t& nWeight);
+    bool GetExpectedStakeTime(uint64_t& nExpected);
     bool CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64_t nSearchInterval, int64_t nFees, CTransaction& txNew, CKey& key);
 
     std::string SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);


### PR DESCRIPTION
This change makes the "time to earn reward" estimate much more realistic.

Previously the code was assuming 1-minute blocks, which we just aren't seeing.

Old logic:

"you have weight 1000, network has weight 4000, so you're 25% of the network, so you get 4 minute blocks"...

That's only true if the network gets 1 minute blocks, which it currently doesn't.
