### PR TITLE
wallet treats transferred coins as "immature"

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -352,37 +352,44 @@ Value importwalletdat(const Array& params, bool fHelp)
     int64_t nStart;
     bool fFirstRun = false;
 
-    printf("here before an error");
     pwalletImport = new CWallet(params[0].get_str().c_str());
     DBErrors nLoadWalletRet = pwalletImport->LoadWalletImport(fFirstRun);
-    printf("not here though");
+
+    // Handle encrypted wallets. Wallest first need to be unlocked before the keys
+    // can be added into your clam wallet. 
+    if (pwalletImport->IsCrypted() && pwalletImport->IsLocked()) {
+        printf("Wallet it crypted");
+        SecureString strWalletPass;
+        strWalletPass.reserve(100);
+        strWalletPass = params[1].get_str().c_str();
+        if (strWalletPass.length() > 0)
+        {
+            if (!pwalletImport->Unlock(strWalletPass))
+                throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect for the wallet your attempting to import.");
+        } else {
+            printf("no password");
+            throw JSONRPCError(RPC_WALLET_ERROR,
+                "importwalletdat <file> <passphrase> Your attempting to import a encrypted wallet. A password for the wallet your attemping to import is required.");
+        }
+    }
 
     std::ostringstream strErrors;
     if (nLoadWalletRet != DB_LOAD_OK)
         {
             if (nLoadWalletRet == DB_CORRUPT)
-                strErrors << _("Error loading wallet.dat: Wallet corrupted") << "\n";
-            else if (nLoadWalletRet == DB_NONCRITICAL_ERROR)
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error loading wallet.dat: Wallet corrupted");
+            else if (nLoadWalletRet == DB_LOAD_FAIL)
             {
-                string msg(_("Warning: error reading wallet.dat! All keys read correctly, but transaction data"
-                             " or address book entries might be missing or incorrect."));
-            }
-            else if (nLoadWalletRet == DB_TOO_NEW)
-                strErrors << _("Error loading wallet.dat: Wallet requires newer version of Clam") << "\n";
-            else if (nLoadWalletRet == DB_NEED_REWRITE)
-            {
-                strErrors << _("Wallet needed to be rewritten: restart Clam to complete") << "\n";
-                printf("%s", strErrors.str().c_str());
+                throw JSONRPCError(RPC_WALLET_ERROR, "Walletfile failed to load");
             }
             else
-                strErrors << _("Error loading wallet.dat") << "\n";
+                printf("Non fatal errors loading wallet file\n");
     }
 
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         LOCK(pwalletImport->cs_wallet);
 
-        //map<CBitcoinAddress,CKeyDump> mapDump;
         std::set<CKeyID> setKeys;
         pwalletImport->GetKeys(setKeys);
 
@@ -405,11 +412,11 @@ Value importwalletdat(const Array& params, bool fHelp)
                 pwalletMain->AddKey(key);
                 pwalletMain->SetAddressBookName(keyid, strLabel);
                 pwalletMain->mapKeyMetadata[keyid].nCreateTime = nTime;
-                //mapDump[*it] = CKeyDump(key.GetSecret());
             }
         }
     }
     
+    // Clean up unregistered wallet
     UnregisterWallet(pwalletImport);
     delete pwalletImport;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -69,7 +69,6 @@ bool CWallet::AddKey(const CKey& key)
         return true;
     }
     if (!IsCrypted()) {
-        printf("not encrypted?\n");
         return CWalletDB(strWalletFile).WriteKey(pubkey, key.GetPrivKey(), mapKeyMetadata[pubkey.GetID()]);
     }
     return true;
@@ -1122,13 +1121,7 @@ void CWallet::AvailableCoinsMinConf(vector<COutput>& vCoins, int nConf) const
 
             if (!pcoin->IsFinal())
                 continue;
-            
-            if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
-                 continue;
-  
-            if (pcoin->IsCoinStake() && pcoin->GetBlocksToMaturity() > 0)
-                 continue;
-  
+
             if(pcoin->GetDepthInMainChain() < nConf)
                 continue;
 
@@ -1522,7 +1515,7 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, ui
     set<pair<const CWalletTx*,unsigned int> > setCoins;
     int64_t nValueIn = 0;
 
-    if (!SelectCoinsSimple(nBalance - nReserveBalance, GetTime(), 1, setCoins, nValueIn))
+    if (!SelectCoinsSimple(nBalance - nReserveBalance, GetTime(), nCoinbaseMaturity + 10, setCoins, nValueIn))
         return false;
 
     if (setCoins.empty())
@@ -1565,42 +1558,6 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, ui
     return true;
 }
 
-bool CWallet::GetExpectedStakeTime(uint64_t& nExpected)
-{
-    unsigned int nBits = GetNextTargetRequired(pindexBest, true);
-    CBigNum bnTarget;
-    bnTarget.SetCompact(nBits);
-    int64_t nBalance = GetBalance();
-    set<pair<const CWalletTx*,unsigned int> > setCoins;
-    int64_t nValueIn = 0;
-    double fail = 1;
-
-    if (!SelectCoinsSimple(nBalance, GetTime(), 1, setCoins, nValueIn))
-        return false;
-
-    CTxDB txdb("r");
-    BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
-    {
-        CTxIndex txindex;
-        {
-            LOCK2(cs_main, cs_wallet);
-            if (!txdb.ReadTxIndex(pcoin.first->GetHash(), txindex))
-                continue;
-        }
-
-        // p(A or B) = p(not((not A) and (not B))) = 1 - (p(1 - A) * p(1 - B))
-        int64_t nTimeWeight = GetWeight((int64_t)pcoin.first->nTime, (int64_t)GetTime());
-        CBigNum bnCoinDayWeight = CBigNum(pcoin.first->vout[pcoin.second].nValue) * nTimeWeight / COIN / (24 * 60 * 60);
-		if (bnCoinDayWeight != 0) {
-			CBigNum bnTries(CBigNum(~uint256(0)) / (bnCoinDayWeight * bnTarget));
-			fail *= 1 - 1.0/bnTries.getulong();
-		}
-    }
-
-    nExpected = 1 / (1 - fail);
-    return true;
-}
-
 bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64_t nSearchInterval, int64_t nFees, CTransaction& txNew, CKey& key)
 {
     CBlockIndex* pindexPrev = pindexBest;
@@ -1627,7 +1584,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     int64_t nValueIn = 0;
 
     // Select coins with suitable depth
-    if (!SelectCoinsSimple(nBalance - nReserveBalance, txNew.nTime, 1, setCoins, nValueIn))
+    if (!SelectCoinsSimple(nBalance - nReserveBalance, txNew.nTime, nCoinbaseMaturity + 10, setCoins, nValueIn))
         return false;
 
     if (setCoins.empty())
@@ -1708,10 +1665,10 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                         break;  // unable to find corresponding public key
                     }
 
-                    if (key.GetPubKey() != vchPubKey)
-                    {
-                        if (fDebug && GetBoolArg("-printcoinstake"))
-                            printf("CreateCoinStake : invalid key for kernel type=%d\n", whichType);
+                if (key.GetPubKey() != vchPubKey)
+                {
+                    if (fDebug && GetBoolArg("-printcoinstake"))
+                        printf("CreateCoinStake : invalid key for kernel type=%d\n", whichType);
                         break; // keys mismatch
                     }
 
@@ -1745,7 +1702,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         // Attempt to add more inputs
         // Only add coins of the same key/address as kernel
         if (txNew.vout.size() == 2 && ((pcoin.first->vout[pcoin.second].scriptPubKey == scriptPubKeyKernel || pcoin.first->vout[pcoin.second].scriptPubKey == txNew.vout[1].scriptPubKey))
-            && (pcoin.first->GetHash() != txNew.vin[0].prevout.hash || pcoin.second != txNew.vin[0].prevout.n))
+            && pcoin.first->GetHash() != txNew.vin[0].prevout.hash)
         {
             int64_t nTimeWeight = GetWeight((int64_t)pcoin.first->nTime, (int64_t)txNew.nTime);
 
@@ -1762,7 +1719,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
             if (pcoin.first->vout[pcoin.second].nValue >= nStakeCombineThreshold)
                 continue;
             // Do not add input that is still too young
-            if (nTimeWeight < 0)
+            if (nTimeWeight < nStakeMinAge)
                 continue;
 
             txNew.vin.push_back(CTxIn(pcoin.first->GetHash(), pcoin.second));


### PR DESCRIPTION
Dooglus, 

I believe this should fix the issue we were seeing with coins being immature when they shoudn't be. 

AvailableCoinsMinConf now only checks the 510 blocks when its a coinstake transactions, all other transactions will become available after 10 confirmations + the 4 hours of course. 

Checking for IsCoinBase() should not be required as all the POW blocks that were created are 30k+ blocks deep at this point.

Reopened from issue #13 
