### PR TITLE
fix compilatiion warning

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -446,7 +446,7 @@ long hex2long(const char* hexString)
 
     while (*hexString && ret >= 0) 
     {
-        ret = (ret << 4) | hextable[*hexString++];
+        ret = (ret << 4) | hextable[int(*hexString++)];
     }
 
     return ret; 


### PR DESCRIPTION
Fix "util.cpp:449:49: warning: array subscript has type ‘char’ [-Wchar-subscripts]".
