### PR TITLE
Use $(MAKE) to invoke make

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -155,7 +155,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..."; cd leveldb; make libleveldb.a libmemenv.a; cd ..;
+	@echo "Building LevelDB ..."; cd leveldb; $(MAKE) libleveldb.a libmemenv.a; cd ..;
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:


### PR DESCRIPTION
then we don't get a warning when building leveldb.

```
make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
```
