### PR TITLE
Have 'getpeerinfo' show the peers' time offsets relative to our own.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3225,6 +3225,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!IsInitialBlockDownload())
             Checkpoints::AskForPendingSyncCheckpoint(pfrom);
 
+        pfrom->nTimeOffset = nTime - GetTime();
+
         if (GetBoolArg("-synctime", true))
             AddTimeData(pfrom->addr, nTime);
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -579,6 +579,7 @@ void CNode::copyStats(CNodeStats &stats)
     X(nTimeConnected);
     X(addrName);
     X(nVersion);
+    X(nTimeOffset);
     X(strSubVer);
     X(fInbound);
     X(nStartingHeight);

--- a/src/net.h
+++ b/src/net.h
@@ -119,6 +119,7 @@ public:
     int64_t nTimeConnected;
     std::string addrName;
     int nVersion;
+    int nTimeOffset;
     std::string strSubVer;
     bool fInbound;
     int nStartingHeight;
@@ -198,6 +199,7 @@ public:
     std::string addrName;
     CService addrLocal;
     int nVersion;
+    int nTimeOffset;
     std::string strSubVer;
     bool fOneShot;
     bool fClient;
@@ -255,6 +257,7 @@ public:
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
+        nTimeOffset = 0;
         strSubVer = "";
         fOneShot = false;
         fClient = false; // set by version message

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -87,6 +87,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
         if (stats.dPingWait > 0.0)
             obj.push_back(Pair("pingwait", stats.dPingWait));
         obj.push_back(Pair("version", stats.nVersion));
+        obj.push_back(Pair("timeoffset", stats.nTimeOffset));
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));


### PR DESCRIPTION
This should be useful for debugging time issues in the future.

Example:

```
{
    "addr" : "a.b.c.d",
    "services" : "00000001",
    "lastsend" : 1417333771,
    "lastrecv" : 1417333808,
    "conntime" : 1417333770,
    "pingtime" : 0.86318900,
    "version" : 60014,
    "timeoffset" : -2, <-- this is new
    "subver" : "/Satoshi:1.4.3/",
    "inbound" : false,
    "startingheight" : 230992,
    "banscore" : 0
}
```
