### PR TITLE
fix 'WalletUpdateSpent found spent coin' logging

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -395,7 +395,7 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock)
                     LogPrintf("WalletUpdateSpent: bad wtx %s\n", wtx.GetHash().ToString());
                 else if (!wtx.IsSpent(txin.prevout.n) && IsMine(wtx.vout[txin.prevout.n]))
                 {
-                    LogPrintf("WalletUpdateSpent found spent coin %s CLAM %s\n", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
+                    LogPrintf("WalletUpdateSpent found spent coin %s CLAM %s\n", FormatMoney(GetCredit(wtx.vout[txin.prevout.n])), wtx.GetHash().ToString());
                     wtx.MarkSpent(txin.prevout.n);
                     wtx.WriteToDisk();
                     NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);


### PR DESCRIPTION
When logging the spend of an output, show the output's value, not the sum off all my outputs in the partially spent transaction.

I have a 1000 CLAM output that I split into 200 5 CLAM outputs and left to stake.

When each one of them staked, I used to see:

```
WalletUpdateSpent found spent coin 1000.00 CLAM [...]
```

which made it look like the whole 1000 CLAMs had been spent.

After this fix I see:

```
WalletUpdateSpent found spent coin 5.00 CLAM [...]
```

which is more like the truth, and saves having to sum up all the outputs of the spent output's transaction too.
