### PR TITLE
I nearly lost some CLAMs earlier due to a JSON typo:

### DIFF
--- a/src/json/json_spirit_reader_template.h
+++ b/src/json/json_spirit_reader_template.h
@@ -408,6 +408,11 @@ namespace json_spirit
     	    throw_error( begin, "not a string" );
         }
 
+        static void throw_trailing_junk( Iter_type begin, Iter_type end )
+        {
+    	    throw_error( begin, "trailing junk" );
+        }
+
         template< typename ScannerT >
         class definition
         {
@@ -444,7 +449,8 @@ namespace json_spirit
                 // actual grammer
 
                 json_
-                    = value_ | eps_p[ &throw_not_value ]
+                    = (value_ | eps_p[ &throw_not_value ])
+                    >> !( anychar_p >> eps_p[ &throw_trailing_junk ] )
                     ;
 
                 value_


### PR DESCRIPTION
```
> createrawtransaction '[{"txid":"deadbeef","vout":1}]' '{"xADDR1":5},"xADDR2":555}'
```

Note the typo'ed '}' after the 5. The 555 was silently ignored, and the command succeeded. Bad JSON like this should be an error.
