### PR TITLE
Add -maxstakevalue=X config option to prevent outputs worth more than X

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -42,7 +42,7 @@ bool fMinimizeCoinAge;
 unsigned int nNodeLifespan;
 unsigned int nDerivationMethodIndex;
 unsigned int nMinerSleep;
-unsigned int nMaxStakeValue;
+int64_t nMaxStakeValue;
 bool fUseFastIndex;
 enum Checkpoints::CPMode CheckpointsMode;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -25,7 +25,7 @@ int64_t nTransactionFee = MIN_TX_FEE;
 int64_t nReserveBalance = 0;
 int64_t nMinimumInputValue = 0;
 
-extern unsigned int nMaxStakeValue;
+extern int64_t nMaxStakeValue;
 
 static unsigned int GetStakeSplitAge() { return 1 * 24 * 60 * 60; }
 


### PR DESCRIPTION
Add -maxstakevalue=X config option to prevent outputs worth more than X CLAM from staking.

I sometimes receive large outputs and forget to split them into smaller amounts before they stake once. Then I have to wait 8 hours until I can split them.

This lets me put:

```
maxstakevalue=20
```

in clam.conf, and know that any outputs over 20 CLAM won't be considered for staking.
