### PR TITLE
Have 'getblock' work with 8 or more characters of a block hash prefix.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -251,7 +251,6 @@ Value getblock(const Array& params, bool fHelp)
     } else {
         pblockindex = NULL;
 
-        // std::map<uint256, CBlockIndex*> mapBlockIndex;
         BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex) {
             if (item.first.GetHex().substr(0, len) == strHash) {
                 pblockindex = item.second;


### PR DESCRIPTION
Previously it required the entire block hash.

We could always do this:

```
$ cc getblock ec64deeb7f1295216f20ce5dbe68b0bd28189a5a644a111e722c05451d51e66c |
  grep -E '"(height|hash)"'
    "hash" : "ec64deeb7f1295216f20ce5dbe68b0bd28189a5a644a111e722c05451d51e66c",
    "height" : 175000,
```

Now we can do this too:

```
$ cc getblock ec64deeb |
  grep -E '"(height|hash)"'
    "hash" : "ec64deeb7f1295216f20ce5dbe68b0bd28189a5a644a111e722c05451d51e66c",
    "height" : 175000,
```

I made it insist on at least 8 characters:

```
$ cc getblock ec64dee |
  grep -E '"(height|hash)"'
error: {"code":-1,"message":"Please provide at least the first 8 digits of the block hash"}
```

It does a linear search through all the blocks in the map, so it's a little slow - but if you don't know the full block hash it's better than nothing.
