### PR TITLE
We need more granularity on fee amount. Also it was rounding down

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1591,10 +1591,10 @@ Value settxfee(const Array& params, bool fHelp)
     if (fHelp || params.size() < 1 || params.size() > 1 || AmountFromValue(params[0]) < MIN_TX_FEE)
         throw runtime_error(
             "settxfee <amount>\n"
-            "<amount> is a real and is rounded to the nearest 0.01");
+            "<amount> is a real and is rounded to the nearest 0.0001");
 
     nTransactionFee = AmountFromValue(params[0]);
-    nTransactionFee = (nTransactionFee / CENT) * CENT;  // round to cent
+    nTransactionFee = ((nTransactionFee + CENT/200) / (CENT/100)) * (CENT/100);  // round to hundredth of cent
 
     return true;
 }


### PR DESCRIPTION
```
$ clamd help settxfee
settxfee <amount>
<amount> is a real and is rounded to the nearest 0.01
```

Two problems: 0.01 is too big - the default is 0.0001.
And it wasn't rounding to the nearest, it was rounding down.

This fixes both of those problems.
