### PR TITLE
Some transactions pay to the same address hundreds of times.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -416,14 +416,19 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock)
             map<uint256, CWalletTx>::iterator mi = mapWallet.find(hash);
             CWalletTx& wtx = (*mi).second;
 
+            bool fMine = false;
             BOOST_FOREACH(const CTxOut& txout, tx.vout)
             {
                 if (IsMine(txout))
                 {
                     wtx.MarkUnspent(&txout - &tx.vout[0]);
-                    wtx.WriteToDisk();
-                    NotifyTransactionChanged(this, hash, CT_UPDATED);
+                    fMine = true;
                 }
+            }
+
+            if (fMine) {
+                wtx.WriteToDisk();
+                NotifyTransactionChanged(this, hash, CT_UPDATED);
             }
         }
 


### PR DESCRIPTION
We don't want to re-write the transaction to disk for every output in the transaction.

Proposed fix for #156.

It appears to work, but peer review would be appreciated.