### PR TITLE
Maintain a map storing the amount staked by each address so that 'getsta...

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -126,6 +126,8 @@ void UnregisterWallet(CWalletInterface* pwalletIn);
 void UnregisterAllWallets();
 /** Push an updated transaction to all registered wallets */
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fConnect = true);
+/** Inform all registered wallets of a change in stake reward */
+void StakeToWallets(const CScript& script, int64_t nStakeReward, bool fConnect = true);
 /** Ask wallets to resend their transactions */
 void ResendWalletTransactions(bool fForce = false);
 
@@ -1338,6 +1340,7 @@ public:
 class CWalletInterface {
 protected:
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock, bool fConnect) =0;
+    virtual void StakeTransaction(const CScript& script, int64_t nStakeReward, bool fConnect) =0;
     virtual void EraseFromWallet(const uint256 &hash) =0;
     virtual void SetBestChain(const CBlockLocator &locator) =0;
     virtual void UpdatedTransaction(const uint256 &hash) =0;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -437,6 +437,8 @@ void CWallet::MarkDirty()
         BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
             item.second.MarkDirty();
     }
+
+    fAddressRewardsReady = false;
 }
 
 bool CWallet::AddToWallet(const CWalletTx& wtxIn)
@@ -607,6 +609,37 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock, bool
     }
 
     AddToWalletIfInvolvingMe(tx, pblock, true);
+}
+
+void CWallet::StakeTransaction(const CScript& script, int64_t nStakeReward, bool fConnect) {
+    if (!fAddressRewardsReady) {
+        LogPrintf("not tracking stake rewards yet\n");
+        return;
+    }
+
+    if (!fConnect)
+        LogPrintf("stake tx disconnecting %s\n", FormatMoney(nStakeReward));
+    else
+        LogPrintf("stake tx connecting    %s\n", FormatMoney(nStakeReward));
+
+    CTxDestination address;
+    if (!ExtractDestination(script, address)) {
+        LogPrintf("can't extract destination\n");
+        return;
+    }
+
+    std::string addr(CBitcoinAddress(address).ToString());
+    if (!::IsMine(*this, address)) {
+        LogPrintf("address %s is not mine\n", addr);
+        return;
+    }
+
+    mapAddressRewards["*"] += nStakeReward;
+    mapAddressRewards[addr] += nStakeReward;
+    LogPrintf("stake %s for destination: %s; global up to %s, address up to %s\n",
+              FormatMoney(nStakeReward), addr,
+              FormatMoney(mapAddressRewards["*"]),
+              FormatMoney(mapAddressRewards[addr]));
 }
 
 void CWallet::EraseFromWallet(const uint256 &hash)
@@ -2654,6 +2687,49 @@ void CWallet::DisableTransaction(const CTransaction &tx)
             }
         }
     }
+}
+
+void CWallet::SumStakingRewards()
+{
+    mapAddressRewards.clear();
+
+    int nWalletTx = 0, nStakeTx = 0;
+
+    string strAccount;
+    int64_t nFee;
+    CTxDestination address;
+    list<pair<CTxDestination, int64_t> > listReceived, listSent;
+
+    typedef std::map<uint256, CWalletTx> TMapWallet;
+    BOOST_FOREACH(TMapWallet::value_type& entry, mapWallet)
+    {
+        const CWalletTx& wtx = entry.second;
+        if (wtx.IsCoinStake() &&
+            IsFinalTx(wtx) &&
+            wtx.GetDepthInMainChain() > 0 &&
+            wtx.vout.size() > 1) {
+
+            if (!ExtractDestination(wtx.vout[1].scriptPubKey, address)) {
+                LogPrintf("can't extract destination\n");
+                continue;
+            }
+
+            std::string addr(CBitcoinAddress(address).ToString());
+            if (!::IsMine(*this, address)) {
+                LogPrintf("address %s is not mine\n", addr);
+                continue;
+            }
+
+            wtx.GetAmounts(listReceived, listSent, nFee, strAccount);
+            mapAddressRewards["*"] -= nFee;
+            mapAddressRewards[addr] -= nFee;
+            nStakeTx++;
+        }
+        
+        nWalletTx++;
+    }
+    LogPrintf("CWallet::SumStakingRewards() found %d of %d tx to be stakes\n", nStakeTx, nWalletTx);
+    fAddressRewardsReady = true;
 }
 
 bool CReserveKey::GetReservedKey(CPubKey& pubkey)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -108,6 +108,9 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
+    std::map<std::string, int64_t> mapAddressRewards; // a running total of staking rewards collected per address
+    bool fAddressRewardsReady;                        // whether we are keeping the running total yet or not
+
     CWallet()
     {
         nWalletVersion = FEATURE_BASE;
@@ -116,6 +119,7 @@ public:
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = NULL;
         nOrderPosNext = 0;
+        fAddressRewardsReady = false;
     }
     CWallet(std::string strWalletFileIn)
     {
@@ -126,6 +130,7 @@ public:
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = NULL;
         nOrderPosNext = 0;
+        fAddressRewardsReady = false;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -188,6 +193,7 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock, bool fConnect = true);
+    void StakeTransaction(const CScript& script, int64_t nStakeReward, bool fConnect = true);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256 &hash);
     void ClearOrphans();
@@ -327,6 +333,7 @@ public:
 
     void FixSpentCoins(int& nMismatchSpent, int64_t& nBalanceInQuestion, bool fCheckOnly = false);
     void DisableTransaction(const CTransaction &tx);
+    void SumStakingRewards();
 
     /** Address book entry changed.
      * @note called with lock cs_wallet held.


### PR DESCRIPTION
...kedbyaddress' doesn't have to iterate through the whole wallet each time.

Proposed fix for #158.

"getstakedbyaddress" is very fast now, at least when you are enquiring about stakes with the default (1) number of confirmations.

I didn't put locks around any of this code. Is it necessary? I suppose it's possible that a block is found (possibly even causing a reorg) while CWallet::SumStakingRewards() is running. Do we need to somehow protect against that?