### PR TITLE
Allow decimal "money" amounts for money-valued config variables.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -350,9 +350,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     nNodeLifespan = GetArg("-addrlifespan", 7);
     fUseFastIndex = GetBoolArg("-fastindex", true);
     nMinerSleep = GetArg("-minersleep", 500);
-    nMaxStakeValue = GetArg("-maxstakevalue", 0) * COIN;
-    nSplitSize = GetArg("-splitsize", 0) * COIN;
-    nCombineLimit = GetArg("-combinelimit", 1) * COIN;
+    nMaxStakeValue = GetMoneyArg("-maxstakevalue", 0*COIN);
+    nSplitSize     = GetMoneyArg("-splitsize",     0*COIN);
+    nCombineLimit  = GetMoneyArg("-combinelimit",  1*COIN);
 
     // we want to avoid spending coins in these addresses if possible
     if (mapArgs.count("-spendlast")) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -11,6 +11,7 @@
 #include "uint256.h"
 #include "version.h"
 #include "clamspeech.h"
+#include "rpcserver.h"
 
 #include <algorithm>
 //For clamspeech until beter solution derivied.
@@ -565,6 +566,26 @@ int64_t GetArg(const std::string& strArg, int64_t nDefault)
 {
     if (mapArgs.count(strArg))
         return atoi64(mapArgs[strArg]);
+    return nDefault;
+}
+
+int64_t GetMoneyArg(const std::string& strArg, int64_t nDefault)
+{
+    json_spirit::Value valAmount;
+    string message;
+    if (mapArgs.count(strArg)) {
+        if (read_string(mapArgs[strArg], valAmount)) {
+            try {
+                return AmountFromValue(valAmount);
+            } catch (json_spirit::Object& objError) {
+                message = find_value(objError, "message").get_str();
+            } catch (runtime_error e) {
+                message = e.what();
+            }
+        } else
+            message = "can't parse value";
+        LogPrintf("Error setting %s: %s\n", strArg, message);
+    }
     return nDefault;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -378,6 +378,15 @@ std::string GetArg(const std::string& strArg, const std::string& strDefault);
 int64_t GetArg(const std::string& strArg, int64_t nDefault);
 
 /**
+ * Return money-valued argument or default value
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @param default (e.g. 1.23)
+ * @return command-line argument (0 if invalid number) or default value
+ */
+int64_t GetMoneyArg(const std::string& strArg, int64_t nDefault);
+
+/**
  * Return boolean argument or default value
  *
  * @param strArg Argument to get (e.g. "-foo")


### PR DESCRIPTION
Previously it was ignoring the fractional parts.