### PR TITLE
New flag -creditstakestoaccounts ...

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -52,7 +52,7 @@ int64_t nMaxStakeValue;
 int64_t nSplitSize;
 int64_t nCombineLimit;
 bool fUseFastIndex;
-bool fCreditStakeAddressAccounts;
+bool fCreditStakesToAccounts;
 enum Checkpoints::CPMode CheckpointsMode;
 vector<CKeyID> vChangeAddresses;
 set<CBitcoinAddress> setSpendLastAddresses;
@@ -350,7 +350,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     nNodeLifespan = GetArg("-addrlifespan", 7);
     fUseFastIndex = GetBoolArg("-fastindex", true);
-    fCreditStakeAddressAccounts = GetBoolArg("-creditstakeaddressaccounts", false);
+    fCreditStakesToAccounts = GetBoolArg("-creditstakestoaccounts", false);
     nMinerSleep = GetArg("-minersleep", 500);
     nMaxStakeValue = GetMoneyArg("-maxstakevalue", 0*COIN);
     nSplitSize     = GetMoneyArg("-splitsize",     0*COIN);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -52,6 +52,7 @@ int64_t nMaxStakeValue;
 int64_t nSplitSize;
 int64_t nCombineLimit;
 bool fUseFastIndex;
+bool fCreditStakeAddressAccounts;
 enum Checkpoints::CPMode CheckpointsMode;
 vector<CKeyID> vChangeAddresses;
 set<CBitcoinAddress> setSpendLastAddresses;
@@ -349,6 +350,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     nNodeLifespan = GetArg("-addrlifespan", 7);
     fUseFastIndex = GetBoolArg("-fastindex", true);
+    fCreditStakeAddressAccounts = GetBoolArg("-creditstakeaddressaccounts", false);
     nMinerSleep = GetArg("-minersleep", 500);
     nMaxStakeValue = GetMoneyArg("-maxstakevalue", 0*COIN);
     nSplitSize     = GetMoneyArg("-splitsize",     0*COIN);

--- a/src/main.h
+++ b/src/main.h
@@ -109,6 +109,7 @@ extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;
 
 extern bool fMinimizeCoinAge;
+extern bool fCreditStakeAddressAccounts;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;

--- a/src/main.h
+++ b/src/main.h
@@ -109,7 +109,7 @@ extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;
 
 extern bool fMinimizeCoinAge;
-extern bool fCreditStakeAddressAccounts;
+extern bool fCreditStakesToAccounts;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1248,14 +1248,21 @@ Value listaccounts(const Array& params, bool fHelp)
         list<pair<CTxDestination, int64_t> > listReceived;
         list<pair<CTxDestination, int64_t> > listSent;
 
-        // don't count staking in account balances - if you stake 5 into 6, it was adding 6, and not taking off the 5
-        if (wtx.IsCoinBase() || wtx.IsCoinStake())
+        // don't count proof-of-work rewards in account balances
+        if (wtx.IsCoinBase())
             continue;
 
         int nDepth = wtx.GetDepthInMainChain();
         if (nDepth < 0)
             continue;
         wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount);
+
+        // count staking reward in the appropriate account
+        if (wtx.IsCoinStake()) {
+            mapAccountBalances[fCreditStakeAddressAccounts ? pwalletMain->mapAddressBook[listSent.front().first] : ""] -= nFee;
+            continue;
+        }
+
         mapAccountBalances[strSentAccount] -= nFee;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
             mapAccountBalances[strSentAccount] -= s.second;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1259,7 +1259,14 @@ Value listaccounts(const Array& params, bool fHelp)
 
         // count staking reward in the appropriate account
         if (wtx.IsCoinStake()) {
-            mapAccountBalances[fCreditStakeAddressAccounts ? pwalletMain->mapAddressBook[listSent.front().first] : ""] -= nFee;
+            if (fCreditStakesToAccounts) {
+                CTxDestination td(listSent.front().first);
+                if (pwalletMain->mapAddressBook.count(td))
+                    mapAccountBalances[pwalletMain->mapAddressBook[td]] -= nFee;
+                else
+                    mapAccountBalances[""] -= nFee;
+            } else
+                mapAccountBalances[""] -= nFee;
             continue;
         }
 


### PR DESCRIPTION
... to say whether to credit staking rewards to the account to which the staking output belongs (=1) or to the "" account (=0, default).