### PR TITLE
Implement -combineany flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@ unsigned int nMinerSleep;
 int64_t nMaxStakeValue;
 int64_t nSplitSize;
 int64_t nCombineLimit;
+bool fCombineAny;
 bool fUseFastIndex;
 bool fCreditStakesToAccounts;
 enum Checkpoints::CPMode CheckpointsMode;
@@ -360,6 +361,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     nMaxStakeValue = GetMoneyArg("-maxstakevalue", 0*COIN);
     nSplitSize     = GetMoneyArg("-splitsize",     0*COIN);
     nCombineLimit  = GetMoneyArg("-combinelimit",  1*COIN);
+    fCombineAny    = GetBoolArg( "-combineany",    false );
 
     // we want to avoid spending coins in these addresses if possible
     if (mapArgs.count("-spendlast")) {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -34,6 +34,7 @@ int     nMaxOutputsToSpend = 500; // each output we spend adds 147 or 148 bytes 
 extern int64_t nMaxStakeValue;
 extern int64_t nSplitSize;
 extern int64_t nCombineLimit;
+extern bool fCombineAny;
 
 static unsigned int GetStakeSplitAge() { return 1 * 24 * 60 * 60; }
 
@@ -2236,8 +2237,9 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         // we're not splitting the output, so attempt to add more inputs
         BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
         {
-            // Only add coins of the same key/address as kernel
-            if ((pcoin.first->vout[pcoin.second].scriptPubKey == scriptPubKeyKernel ||
+            // Only add coins of the same key/address as kernel, or if fCombineAny is true
+            if ((fCombineAny ||
+                 pcoin.first->vout[pcoin.second].scriptPubKey == scriptPubKeyKernel ||
                  pcoin.first->vout[pcoin.second].scriptPubKey == txNew.vout[1].scriptPubKey) &&
                 (pcoin.first->GetHash() != txNew.vin[0].prevout.hash ||
                  pcoin.second != txNew.vin[0].prevout.n))


### PR DESCRIPTION
Add -combineany flag to allow staking to merge any small outputs together regardless of their address.