### PR TITLE
Add RCP commands 'setstaketo' and 'setrewardto'

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -289,7 +289,7 @@ static const CRPCCommand vRPCCommands[] =
     { "dumpprivkey",            &dumpprivkey,            false,     false,     true },
     { "dumpwallet",             &dumpwallet,             true,      false,     true },
     { "importwallet",           &importwallet,           false,     false,     true },
-    { "importwalletdump",       &importwalletdump,           false,  false,   true },
+    { "importwalletdump",       &importwalletdump,       false,     false,     true },
     { "importprivkey",          &importprivkey,          false,     false,     true },
     { "listunspent",            &listunspent,            false,     false,     true },
     { "settxfee",               &settxfee,               false,     false,     true },
@@ -300,6 +300,8 @@ static const CRPCCommand vRPCCommands[] =
     { "resendtx",               &resendtx,               false,     true,      true },
     { "makekeypair",            &makekeypair,            false,     true,      false },
     { "setspeech",              &setspeech,              false,     false,     true },
+    { "setstaketo",             &setstaketo,             true,      true,      true },
+    { "setrewardto",            &setrewardto,            true,      true,      true },
 #endif
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -180,5 +180,7 @@ extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fH
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblockbynumber(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getcheckpoint(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setstaketo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setrewardto(const json_spirit::Array& params, bool fHelp);
 
 #endif

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -19,6 +19,11 @@ using namespace json_spirit;
 int64_t nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;
 
+extern CKeyID staketokeyID;
+extern CKeyID rewardtokeyID;
+extern bool fStakeTo;
+extern bool fRewardTo;
+
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, json_spirit::Object& entry);
 
 static void accountingDeprecationCheck()
@@ -1770,6 +1775,48 @@ Value settxfee(const Array& params, bool fHelp)
 
     nTransactionFee = AmountFromValue(params[0]);
     nTransactionFee = ((nTransactionFee + CENT/200) / (CENT/100)) * (CENT/100);  // round to hundredth of cent
+
+    return true;
+}
+
+Value setrewardto(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "setrewardto [address]\n"
+            "Sets the -rewardto address. If address isn't specified, -rewardto is turned off.");
+
+    if (params.size() == 0)
+        fRewardTo = false;
+    else {
+        std::string address = params[0].get_str();
+
+        if (!CBitcoinAddress(address).GetKeyID(rewardtokeyID))
+            return strprintf(_("Bad -rewardto address: '%s'"), address);
+
+        fRewardTo = true;
+    }
+
+    return true;
+}
+
+Value setstaketo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "setstaketo [address]\n"
+            "Sets the -staketo address. If address isn't specified, -staketo is turned off.");
+
+    if (params.size() == 0)
+        fStakeTo = false;
+    else {
+        std::string address = params[0].get_str();
+
+        if (!CBitcoinAddress(address).GetKeyID(staketokeyID))
+            return strprintf(_("Bad -staketo address: '%s'"), address);
+
+        fStakeTo = true;
+    }
 
     return true;
 }


### PR DESCRIPTION
to allow changing the -staketo and -rewardto settings without having to restart the client.