### PR TITLE
Extend createrawtransaction to accept 'locktime' in the output JSON.

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1341,7 +1341,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
         mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
 
-        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
+        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey - with locktime
         mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG << OP_SMALLDATA << OP_CHECKLOCKTIMEVERIFY << OP_DROP));
 
         // Sender provides N pubkeys, receivers provides M signatures

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1341,6 +1341,9 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
         mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
 
+        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
+        mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG << OP_SMALLDATA << OP_CHECKLOCKTIMEVERIFY << OP_DROP));
+
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
 
@@ -2065,6 +2068,11 @@ public:
 void CScript::SetDestination(const CTxDestination& dest)
 {
     boost::apply_visitor(CScriptVisitor(this), dest);
+}
+
+void CScript::SetLockTime(const int64_t nLockTime)
+{
+    *this << nLockTime << OP_CHECKLOCKTIMEVERIFY << OP_DROP;
 }
 
 void CScript::SetMultisig(int nRequired, const std::vector<CPubKey>& keys)

--- a/src/script.h
+++ b/src/script.h
@@ -576,6 +576,7 @@ public:
     bool HasCanonicalPushes() const;
 
     void SetDestination(const CTxDestination& address);
+    void SetLockTime(const int64_t nLockTime);
     void SetMultisig(int nRequired, const std::vector<CPubKey>& keys);
 
     std::string ToString(bool fShort=false) const


### PR DESCRIPTION
Make the 'count' optional.
Make locktime address scripts standard.