### PR TITLE
Remove the 'weight' column from the coin control dialog.

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -118,7 +118,6 @@ CoinControlDialog::CoinControlDialog(QWidget *parent) :
     ui->treeWidget->setColumnWidth(COLUMN_DATE, 110);
     ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 100);
     ui->treeWidget->setColumnWidth(COLUMN_AGE, 60);
-    ui->treeWidget->setColumnWidth(COLUMN_WEIGHT, 60);
     ui->treeWidget->setColumnWidth(COLUMN_PRIORITY, 100);
     ui->treeWidget->setColumnHidden(COLUMN_TXHASH, true);         // store transacton hash in this column, but dont show it
     ui->treeWidget->setColumnHidden(COLUMN_VOUT_INDEX, true);     // store vout index in this column, but dont show it
@@ -627,7 +626,6 @@ void CoinControlDialog::updateView()
         double dPrioritySum = 0;
         int nChildren = 0;
         int nInputSum = 0;
-	int dWeight = 0;
         BOOST_FOREACH(const COutput& out, coins.second)
         {
             int nInputSize = 148; // 180 if uncompressed public key
@@ -688,12 +686,6 @@ void CoinControlDialog::updateView()
             int age = floorf((GetTime() - out.tx->GetTxTime()) / (1440 * nTargetStakeSpacing));
             itemOutput->setText(COLUMN_AGE, strPad(QString::number(age), 5, " "));
 
-            // weight
-            int weight = floorf((GetTime() - out.tx->GetTxTime()) * out.tx->vout[out.i].nValue / BitcoinUnits::factor(BitcoinUnits::BTC) / (double)(1440 * nTargetStakeSpacing));
-            if (weight < 0) weight = 0;
-            itemOutput->setText(COLUMN_WEIGHT, strPad(QString::number(weight), 5, " "));
-            dWeight += weight;
-            
             // priority
             double dPriority = ((double)out.tx->vout[out.i].nValue  / (nInputSize + 78)) * (out.nDepth+1); // 78 = 2 * 34 + 10
             //itemOutput->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPriority));
@@ -730,7 +722,6 @@ void CoinControlDialog::updateView()
             itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
             itemWalletAddress->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(nSum), 15, " "));
             itemWalletAddress->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPrioritySum));
-            itemWalletAddress->setText(COLUMN_WEIGHT, strPad(QString::number((int64_t)dWeight), 5, " "));
         }
     }
     

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -58,7 +58,6 @@ private:
         COLUMN_DATE,
         COLUMN_CONFIRMATIONS,
         COLUMN_AGE,
-        COLUMN_WEIGHT,
         COLUMN_PRIORITY,
         COLUMN_TXHASH,
         COLUMN_VOUT_INDEX,

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -86,14 +86,6 @@
      </column>
      <column>
       <property name="text">
-       <string>Weight</string>
-      </property>
-      <property name="toolTip">
-       <string>Weight</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
        <string>Priority</string>
       </property>
      </column>
@@ -579,7 +571,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Note: Age, Weight, and Priority are not taken into account during staking.</string>
+      <string>Note: Age and Priority are not taken into account during staking.</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Weight is the same as 'amount' for staking coins.