### PR TITLE
Fix #226. Don't crash when someone else stakes and ...

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1297,7 +1297,7 @@ Value listaccounts(const Array& params, bool fHelp)
 
         // count staking reward in the appropriate account
         if (wtx.IsCoinStake()) {
-            if (fCreditStakesToAccounts) {
+            if (fCreditStakesToAccounts && listSent.size()) {
                 CTxDestination td(listSent.front().first);
                 if (pwalletMain->mapAddressBook.count(td))
                     mapAccountBalances[pwalletMain->mapAddressBook[td]] -= nFee;


### PR DESCRIPTION
... sends the reward to us and creditstakestoaccounts=1 is set.