### PR TITLE
Track valid 'create clamour' speech in the blockindex. Add 'listclamours' and 'getclamour' RPC calls.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -309,6 +309,8 @@ public:
         return (vin.size() > 0 && (!vin[0].prevout.IsNull()) && vout.size() >= 2 && vout[0].IsEmpty());
     }
 
+    bool IsCreateClamour(std::string& strHash, std::string& strURL) const;
+
     /** Amount of bitcoins spent by this transaction.
         @return sum of all outputs (note: does not include fees)
      */
@@ -885,6 +887,35 @@ private:
  * to it, but pnext will only point forward to the longest branch, or will
  * be null if the block is not part of the longest chain.
  */
+class CClamour
+{
+public:
+    int nHeight;
+    uint256 txid;
+    std::string strHash;
+    std::string strURL;
+
+    CClamour()
+    {
+    }
+
+    CClamour(int nHeightIn, uint256 txidIn, std::string& strHashIn, std::string& strURLIn)
+    {
+        nHeight = nHeightIn;
+        txid = txidIn;
+        strHash = strHashIn;
+        strURL = strURLIn;
+    }
+
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(nHeight);
+        READWRITE(txid);
+        READWRITE(strHash);
+        READWRITE(strURL);
+    )
+};
+
 class CBlockIndex
 {
 public:
@@ -900,6 +931,8 @@ public:
     int64_t nMoneySupply;
     int64_t nDigsupply;
     int64_t nStakeSupply;
+
+    std::vector<CClamour> vClamour;
 
     unsigned int nFlags;  // ppcoin: block index flags
     enum  
@@ -1144,6 +1177,7 @@ public:
         READWRITE(nMoneySupply);
         READWRITE(nDigsupply);
         READWRITE(nStakeSupply);
+        READWRITE(vClamour);
         READWRITE(nFlags);
         READWRITE(nStakeModifier);
         if (IsProofOfStake())

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -140,6 +140,19 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.push_back(Pair("proofhash", blockindex->hashProof.GetHex()));
     result.push_back(Pair("entropybit", (int)blockindex->GetStakeEntropyBit()));
     result.push_back(Pair("modifier", strprintf("%016x", blockindex->nStakeModifier)));
+    UniValue clamours(UniValue::VARR);
+    BOOST_FOREACH (const CClamour& clamour, blockindex->vClamour)
+    {
+        UniValue entry(UniValue::VOBJ);
+        entry.push_back(Pair("txid", clamour.txid.GetHex()));
+        entry.push_back(Pair("hash", clamour.strHash));
+        if (clamour.strURL.length())
+            entry.push_back(Pair("url", clamour.strURL));
+        clamours.push_back(entry);
+    }
+    if (clamours.size())
+        result.push_back(Pair("clamours", clamours));
+
     UniValue txinfo(UniValue::VARR);
     BOOST_FOREACH (const CTransaction& tx, block.vtx)
     {

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -155,6 +155,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "dumpbootstrap", 1 },
     { "dumpbootstrap", 2 },
     { "validateoutputs", 0 },
+    { "listclamours", 0 },
+    { "listclamours", 1 },
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -313,6 +313,8 @@ static const CRPCCommand vRPCCommands[] =
     { "setstaketo",             &setstaketo,             true,      true,      true },
     { "getrewardto",            &getrewardto,            true,      true,      true },
     { "setrewardto",            &setrewardto,            true,      true,      true },
+    { "getclamour",             &getclamour,             true,      true,      false },
+    { "listclamours",           &listclamours,           true,      true,      false },
 #endif
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -195,4 +195,7 @@ extern UniValue setrewardto(const UniValue& params, bool fHelp);
 extern UniValue sendnotarytransaction(const UniValue& params, bool fHelp);
 extern UniValue getnotarytransaction(const UniValue& params, bool fHelp);
 
+extern UniValue getclamour(const UniValue& params, bool fHelp);
+extern UniValue listclamours(const UniValue& params, bool fHelp);
+
 #endif

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -26,6 +26,8 @@ using namespace boost;
 
 leveldb::DB *txdb; // global pointer for LevelDB object instance
 
+extern map<string, CClamour*> mapClamour;
+
 static leveldb::Options GetOptions() {
     leveldb::Options options;
     int nCacheSizeMB = GetArg("-dbcache", 25);
@@ -388,6 +390,7 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nMoneySupply   = diskindex.nMoneySupply;
         pindexNew->nDigsupply     = diskindex.nDigsupply;
         pindexNew->nStakeSupply   = diskindex.nStakeSupply;
+        pindexNew->vClamour       = diskindex.vClamour;
         pindexNew->nFlags         = diskindex.nFlags;
         pindexNew->nStakeModifier = diskindex.nStakeModifier;
         pindexNew->prevoutStake   = diskindex.prevoutStake;
@@ -588,5 +591,9 @@ bool CTxDB::LoadBlockIndex()
         block.SetBestChain(txdb, pindexFork);
     }
 
+    for (CBlockIndex* pindex = pindexGenesisBlock; pindex; pindex = pindex->pnext)
+        BOOST_FOREACH(CClamour& clamour, pindex->vClamour)
+            mapClamour[clamour.strHash.substr(0, 8)] = &clamour;
+    
     return true;
 }


### PR DESCRIPTION
Requires a reindex of the blockchain, which the current master branch doesn't implement.

I've been testing this by deleting the whole txleveldb/ folder and using a bootstrap.dat to reindex.