### PR TITLE
Clamour page: Change "Petition ID" field to "Petition Hash"

### DIFF
--- a/src/qt/forms/clamourpage.ui
+++ b/src/qt/forms/clamourpage.ui
@@ -46,7 +46,7 @@
          <item row="1" column="0">
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Petition ID:</string>
+            <string>Petition Hash:</string>
            </property>
           </widget>
          </item>
@@ -59,7 +59,7 @@
             <bool>true</bool>
            </property>
            <property name="placeholderText">
-            <string>The ID of the above petition will be shown here.</string>
+            <string>The hash of the above petition will be shown here.</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The field shows the petition hash, not the petition ID.