### PR TITLE
Use a model for clamour petitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ src/qt/moc_bitcoingui.cpp
 src/qt/moc_bitcoinunits.cpp
 src/qt/moc_clamdb.cpp
 src/qt/moc_clamourpage.cpp
+src/qt/moc_clamourpetitionmodel.cpp
 src/qt/moc_clamoursupportmodel.cpp
 src/qt/moc_clientmodel.cpp
 src/qt/moc_coincontroldialog.cpp

--- a/contrib/clam-qt.pro
+++ b/contrib/clam-qt.pro
@@ -243,7 +243,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/notarypage.h \
     src/qt/clamdb.h \
     src/qt/clamourpage.h \
-    src/qt/clamoursupportmodel.h
+    src/qt/clamoursupportmodel.h \
+    src/qt/clamourpetitionmodel.h
 
 SOURCES += src/txdb-leveldb.cpp \
     src/clamspeech.cpp \
@@ -328,7 +329,8 @@ SOURCES += src/txdb-leveldb.cpp \
     src/qt/notarypage.cpp \
     src/qt/clamdb.cpp \
     src/qt/clamourpage.cpp \
-    src/qt/clamoursupportmodel.cpp
+    src/qt/clamoursupportmodel.cpp \
+    src/qt/clamourpetitionmodel.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -104,6 +104,7 @@ QT_MOC_CPP = \
   qt/moc_bitcoinunits.cpp \
   qt/moc_clamdb.cpp \
   qt/moc_clamourpage.cpp \
+  qt/moc_clamourpetitionmodel.cpp \
   qt/moc_clamoursupportmodel.cpp \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
@@ -159,6 +160,7 @@ BITCOIN_QT_H = \
   qt/bitcoinunits.h \
   qt/clamdb.h \
   qt/clamourpage.h \
+  qt/clamourpetitionmodel.h \
   qt/clamoursupportmodel.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
@@ -249,6 +251,7 @@ BITCOIN_QT_CPP = \
   qt/bitcoinunits.cpp \
   qt/clamdb.cpp \
   qt/clamourpage.cpp \
+  qt/clamourpetitionmodel.cpp \
   qt/clamoursupportmodel.cpp \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \

--- a/src/qt/clamourpage.cpp
+++ b/src/qt/clamourpage.cpp
@@ -39,6 +39,7 @@ ClamourPage::ClamourPage(QWidget *parent) :
 
     supportModel = new ClamourSupportModel(this);
     ui->petitionSupportView->setModel(supportModel);
+    connect(ui->petitionSupportView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(searchHighlightedPetition()));
 }
 
 ClamourPage::~ClamourPage()

--- a/src/qt/clamourpage.h
+++ b/src/qt/clamourpage.h
@@ -10,6 +10,7 @@ class ClamourPage;
 }
 class WalletModel;
 class CClamour;
+class ClamourPetitionModel;
 class ClamourSupportModel;
 
 QT_BEGIN_NAMESPACE
@@ -49,12 +50,12 @@ private slots:
 private:
     Ui::ClamourPage *ui;
     WalletModel *model;
+    ClamourPetitionModel *petitionModel;
     ClamourSupportModel *supportModel;
     QMenu *petitionViewContextMenu;
 
     void loadVotes();
     void saveVotes();
-    void clearSearchTable();
 };
 
 #endif // CLAMOURPAGE_H

--- a/src/qt/clamourpetitionmodel.cpp
+++ b/src/qt/clamourpetitionmodel.cpp
@@ -1,0 +1,95 @@
+#include "clamourpetitionmodel.h"
+#include "main.h"
+#include "guiutil.h"
+
+ClamourPetitionModel::ClamourPetitionModel(QWidget *parent) :
+    QAbstractTableModel(parent), petition(0)
+{
+    rowHeaders << tr("Height") << tr("TxID") << tr("Petition Hash") << tr("URL");
+}
+
+int ClamourPetitionModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 4;
+}
+
+int ClamourPetitionModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 1;
+}
+
+QVariant ClamourPetitionModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+    if (!petition)
+        return QVariant();
+
+    switch (role)
+    {
+    case Qt::DisplayRole:
+        switch (index.row())
+        {
+        case Height:
+            return QString::number(petition->nHeight);
+        case TxID:
+            return QString::fromStdString(petition->txid.GetHex());
+        case PetitionHash:
+            return QString::fromStdString(petition->strHash);
+        case URL:
+            return QString::fromStdString(petition->strURL);
+        }
+        break;
+    }
+    return QVariant();
+}
+
+QVariant ClamourPetitionModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation != Qt::Vertical)
+        return QVariant();
+
+    switch (role)
+    {
+    case Qt::DisplayRole:
+        return rowHeaders[section];
+        break;
+    case Qt::ToolTipRole:
+        switch (section)
+        {
+        case Height:
+            return tr("Block height the petition was created at.");
+        case TxID:
+            return tr("Transaction the petition was created with.");
+        case PetitionHash:
+            return tr("Hash of the petition.");
+        case URL:
+            return tr("URL where the petition text may be found.");
+        }
+        break;
+    }
+    return QVariant();
+}
+
+Qt::ItemFlags ClamourPetitionModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return 0;
+    return Qt::ItemFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+}
+
+void ClamourPetitionModel::clear()
+{
+    beginResetModel();
+    petition = 0;
+    endResetModel();
+}
+
+void ClamourPetitionModel::setPetition(CClamour *newPetition)
+{
+    beginResetModel();
+    petition = newPetition;
+    endResetModel();
+}

--- a/src/qt/clamourpetitionmodel.h
+++ b/src/qt/clamourpetitionmodel.h
@@ -1,0 +1,42 @@
+#ifndef CLAMOURPETITIONMODEL_H
+#define CLAMOURPETITIONMODEL_H
+
+#include <QWidget>
+#include <QAbstractTableModel>
+#include <QStringList>
+
+class CClamour;
+
+class ClamourPetitionModel : public QAbstractTableModel
+{
+    Q_OBJECT
+public:
+    explicit ClamourPetitionModel(QWidget *parent = 0);
+
+    enum RowIndex {
+        Height = 0,
+        TxID = 1,
+        PetitionHash = 2,
+        URL = 3,
+    };
+
+    int rowCount(const QModelIndex &parent) const;
+    int columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+
+    Qt::ItemFlags flags(const QModelIndex &index) const;
+
+    void clear();
+    void setPetition(CClamour *newPetition);
+
+signals:
+
+public slots:
+
+private:
+    QStringList rowHeaders;
+    CClamour *petition;
+};
+
+#endif // CLAMOURPETITIONMODEL_H

--- a/src/qt/forms/clamourpage.ui
+++ b/src/qt/forms/clamourpage.ui
@@ -210,11 +210,23 @@
         </layout>
        </item>
        <item>
-        <widget class="QTableWidget" name="searchClamourTable">
+        <widget class="QTableView" name="searchClamourView">
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
          <attribute name="horizontalHeaderHighlightSections">
           <bool>false</bool>
          </attribute>
+         <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
          <attribute name="verticalHeaderHighlightSections">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderShowSortIndicator" stdset="0">
           <bool>false</bool>
          </attribute>
         </widget>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -29,7 +29,7 @@
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <property name="elideMode">
       <enum>Qt::ElideNone</enum>
@@ -422,7 +422,7 @@
      </widget>
      <widget class="QWidget" name="tabSpeech">
       <attribute name="title">
-       <string>CLAMSpeech</string>
+       <string>CLAMSp&amp;eech</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">


### PR DESCRIPTION
Use a custom QAbstractTableModel subclass to model a CClamour.

Also, add a keyboard shortcut for the **CLAMSpeech** tab in the options dialog.