### PR TITLE
Fix GetOrphanRoot() and update checkpoint

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -35,6 +35,7 @@ namespace Checkpoints
         ( 250000,  uint256("0xb560c121438f630401c102767587b70cb0cc7d1e0c09114dd0b91455262aa64c") )
         ( 530000,  uint256("0xf89eedd61837c581b4b8fcb85782066b04f7266b4bd946b583805d330a0ae0cc") )
         ( 777000,  uint256("0x43213b22020b78dab01d5457611a55d7b471ab980a1749898ac9f2b496c5ed3d") )
+        ( 1000000, uint256("0x4bb58b747f305b04d7f71946a9650b059a58f26b44ec05b1f8bd211424c5a586") )
     ;
 
     static MapCheckpoints mapCheckpointsTestnet =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3410,28 +3410,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         LogPrintf("receive version message: version %d, blocks=%d, us=%s, them=%s, peer=%s\n", pfrom->nVersion, pfrom->nStartingHeight, addrMe.ToString(), addrFrom.ToString(), pfrom->addr.ToString());
 
 
-
-    // Be more aggressive with blockchain download. Send new getblocks() message after connection
-    // to new node if waited longer than MAX_TIME_SINCE_BEST_BLOCK.
-    int64 TimeSinceBestBlock = GetTime() - nTimeBestReceived;
-    if (TimeSinceBestBlock > MAX_TIME_SINCE_BEST_BLOCK) {
-        //LogPrintf("INFO: Waiting %d sec which is too long. Sending GetBlocks(0)\n", TimeSinceBestBlock);
-        PushGetBlocks(pfrom, pindexBest, uint256(0));
-    }
-
-        // ppcoin: ask for pending sync-checkpoint if any
-        if (!IsInitialBlockDownload())
-            Checkpoints::AskForPendingSyncCheckpoint(pfrom);
-
-        // CDC v1.3.3: reset counts to detect forked peers
-        pfrom->nHighestHeightRequested = 0;  /* CDC v1.3.3 */
-        pfrom->nHeightBackwards = 0;  /* CDC v1.3.3 */
-        pfrom->nHeightBackwardsLast = GetTime();  /* CDC v1.3.3 */
-
-        pfrom->nTimeOffset = nTime - GetTime();
-
+        int64_t nTimeOffset = nTime - GetTime();
+        pfrom->nTimeOffset = nTimeOffset;
         if (GetBoolArg("-synctime", true))
-            AddTimeData(pfrom->addr, nTime);
+            AddTimeData(pfrom->addr, nTimeOffset);
     }
 
 


### PR DESCRIPTION
GetOrphanRoot() was failing causing the stuck client sync issues. With this update the client syncs from the network without any issue. 

This was only tested on 2 vm's but both synced from the network without issues. Sync went through with no client resets required.  